### PR TITLE
PageTitle 컴포넌트 완성

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16211,6 +16211,19 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "node_modules/typescript": {
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",

--- a/src/component/PageTitle/PageTitle.jsx
+++ b/src/component/PageTitle/PageTitle.jsx
@@ -1,0 +1,11 @@
+import styled from 'styled-components';
+import Typography from '../Typography/Typography';
+
+const PointColorText = styled(Typography)`
+  span {
+    color: ${(props) => props.theme.colors.blue};
+  }
+`;
+const PageTitle = ({ children }) => <PointColorText pageTitle>{children}</PointColorText>;
+
+export default PageTitle;

--- a/src/pages/Home/Home.jsx
+++ b/src/pages/Home/Home.jsx
@@ -1,27 +1,11 @@
-import Button from '../../component/Button/Button';
-import Flex from '../../component/Flex/Flex';
-import Typography from '../../component/Typography/Typography';
+import PageTitle from '../../component/PageTitle/PageTitle';
 
 const Home = () => (
-  <>
-    <Typography header>hi</Typography>
-    <Typography semiHeader>hi</Typography>
-    <Typography contentTitle>hi</Typography>
-    <Typography small>hi</Typography>
-    <Flex justify='space-between'>
-      <h1>h1</h1>
-      <h1>h1</h1>
-    </Flex>
-    <Button>🙏 새 글 작성</Button>
-    <Button color='darkGray'>🙏 새 글 작성</Button>
-    <Button small>✔️ Today</Button>
-    <Button textButton color='red'>
-      작성
-    </Button>
-    <Button textButtonSmall color='blue'>
-      추가
-    </Button>
-  </>
+  <PageTitle>
+    페이지
+    <span> 타이틀 </span>
+    입니다.
+  </PageTitle>
 );
 
 export default Home;


### PR DESCRIPTION
매 상세 페이지마다 위에 있는 페이지 제목을 위한 PageTitle 컴포넌트 입니다.

사용 방법
파란색으로 써줄 글씨를 span태그로 감싸서 PageTitle컴포넌트 안에 넣으면 됩니다.
<img width="192" alt="image" src="https://user-images.githubusercontent.com/64801796/213447350-38918c3e-4f59-4c9e-9224-3b1ee71b5bb1.png">

적용된 모습
<img width="366" alt="image" src="https://user-images.githubusercontent.com/64801796/213447515-56357ce5-4740-4274-bc09-fa8c413acd1c.png">
