### PR TITLE
fix(InputBox): textarea 높이 변경 수정

### DIFF
--- a/src/component/InputBox/InputBox.jsx
+++ b/src/component/InputBox/InputBox.jsx
@@ -70,6 +70,7 @@ const types = {
   homework: `
     width: 100%;
     min-height: 120px;
+    height: auto;
   `,
 
   alert: `
@@ -249,6 +250,7 @@ const InputBox = ({
           onKeyDown={handleResizeHeight}
           onKeyUp={handleResizeHeight}
           onChange={onChange}
+          onFocus={handleResizeHeight}
           disabled={disabled}
         >
           {placeholder}


### PR DESCRIPTION
### 버그 내용

수정 화면에서 `textarea`가 초기 높이로 고정되어 해당 내용을 수정하기 이전까지는 높이가 유지되는 버그가 발견되었습니다.

### 해결 방법

`onFocus`를 이용하여 `textarea`의 높이를 변경해주도록 `eventHandler`를 추가하였습니다.